### PR TITLE
chore(release): v0.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lagoni/modelina",
-  "version": "3.4.0",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lagoni/modelina",
-      "version": "3.4.0",
+      "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lagoni/modelina",
-  "version": "3.4.0",
+  "version": "0.0.0",
   "description": "Library for generating data models based on inputs such as AsyncAPI, OpenAPI, or JSON Schema documents",
   "license": "Apache-2.0",
   "homepage": "https://www.modelina.org",


### PR DESCRIPTION
Version bump in package.json for release [v0.0.0](https://github.com/jonaslagoni/generator-model-sdk/releases/tag/v0.0.0)